### PR TITLE
Fix spelling mistake in info.plist

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -101,7 +101,7 @@
 				<key>queuemode</key>
 				<integer>2</integer>
 				<key>runningsubtext</key>
-				<string>Retriving location/weather...</string>
+				<string>Retrieving location/weather...</string>
 				<key>script</key>
 				<string>ruby dark-sky.rb {query}</string>
 				<key>scriptargtype</key>
@@ -163,7 +163,7 @@
 				<key>queuemode</key>
 				<integer>2</integer>
 				<key>runningsubtext</key>
-				<string>Retriving location/weather...</string>
+				<string>Retrieving location/weather...</string>
 				<key>script</key>
 				<string>ruby dark-sky.rb {query}</string>
 				<key>scriptargtype</key>


### PR DESCRIPTION
Hello! Submitting a small correction here. There were two instances in `info.plist` where "Retrieving location/weather" was misspelled "Retriving location/weather." This pull request fixes that.

Thanks for this great workflow and thanks for considering this fix!